### PR TITLE
Add kramdown-parser-gfm dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'jekyll', '~> 3.6'
 gem 'jekyll-seo-tag'
 gem 'jekyll-sitemap'
+gem "kramdown-parser-gfm"
 
 group :jekyll_plugins do
   gem 'jekyll-algolia'


### PR DESCRIPTION
Hi Pavlos!

I've managed to work out what was happening with the cookie consent stuff on your site (there are some differences between the theme I use on my website and the one you use and that was causing a file to be missed).  In the process of getting everything to go I noticed some other issues, which I'm now submitting as pull requests.

Kind regards,

Paul


After initially installing the gems for this project, I found that the
"kramdown-parser-gfm" library was missing (`jekyll serve` failed with an
error that this library was missing).  Adding it to the `Gemfile` and
rerunning `bundle install` then allowed `jekyll serve` to work as
expected and the development version of the website could be viewed in a
web browser.